### PR TITLE
fix: should gracefully fail if no local tools

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -116,13 +116,15 @@ program
 
           if (tools.length === 0) {
             console.error(
-              chalk.red('❌ No valid tools found in the specified folder')
+              chalk.yellow('⚠️  No valid tools found in the specified folder')
             );
-            process.exit(1);
+            console.error(
+              chalk.blue('🚀 Starting MCP server with no tools loaded')
+            );
+          } else {
+            // Simple output for local-only discovery
+            ToolOutputFormatter.displaySimpleToolResults(tools);
           }
-
-          // Simple output for local-only discovery
-          ToolOutputFormatter.displaySimpleToolResults(tools);
         }
 
         // Start MCP server

--- a/src/multi-source-discovery.ts
+++ b/src/multi-source-discovery.ts
@@ -134,14 +134,38 @@ export class MultiSourceToolDiscovery {
 
     // Check if local directory exists
     if (!existsSync(expandedLocalPath)) {
-      throw new Error(`Local tools path does not exist: ${expandedLocalPath}`);
+      console.warn(
+        chalk.yellow(
+          `⚠️  Local tools directory not found: ${expandedLocalPath}`
+        )
+      );
+      return {
+        tools: [],
+        summary: {
+          total: 0,
+          global: 0,
+          local: 0,
+          conflicts: []
+        }
+      };
     }
 
     try {
       const localDiscovery = new ToolDiscovery(expandedLocalPath, 'local');
       return await localDiscovery.discoverToolsWithMetadata();
     } catch (error) {
-      throw new Error(`Failed to discover local tools: ${error}`);
+      console.warn(
+        chalk.yellow(`⚠️  Failed to discover local tools: ${error}`)
+      );
+      return {
+        tools: [],
+        summary: {
+          total: 0,
+          global: 0,
+          local: 0,
+          conflicts: []
+        }
+      };
     }
   }
 

--- a/src/tool-discovery.ts
+++ b/src/tool-discovery.ts
@@ -18,12 +18,32 @@ export class ToolDiscovery {
 
   async discoverToolsWithMetadata(): Promise<DiscoveryResults> {
     if (!existsSync(this.toolsPath)) {
-      throw new Error(`Tools path does not exist: ${this.toolsPath}`);
+      console.warn(`⚠️  Tools path does not exist: ${this.toolsPath}`);
+      console.warn(`📂 Continuing with no ${this.source} tools loaded`);
+      return {
+        tools: [],
+        summary: {
+          total: 0,
+          global: this.source === 'global' ? 0 : 0,
+          local: this.source === 'local' ? 0 : 0,
+          conflicts: []
+        }
+      };
     }
 
     const stat = statSync(this.toolsPath);
     if (!stat.isDirectory()) {
-      throw new Error(`Tools path is not a directory: ${this.toolsPath}`);
+      console.warn(`⚠️  Tools path is not a directory: ${this.toolsPath}`);
+      console.warn(`📂 Continuing with no ${this.source} tools loaded`);
+      return {
+        tools: [],
+        summary: {
+          total: 0,
+          global: this.source === 'global' ? 0 : 0,
+          local: this.source === 'local' ? 0 : 0,
+          conflicts: []
+        }
+      };
     }
 
     const discoveredTools: DiscoveredTool[] = [];


### PR DESCRIPTION
If no local tools folder found, it should continue with global tools